### PR TITLE
update to VS2022 and some tweaks

### DIFF
--- a/wawl/BaseType.hpp
+++ b/wawl/BaseType.hpp
@@ -1,6 +1,7 @@
 ﻿#pragma once
 #define WAWL_BASE_TYPE_HPP
 
+#include <bit>
 #include <string>
 #include <cstdint>
 #include <type_traits>
@@ -40,7 +41,7 @@ namespace wawl {
 
 		// any handle
 		using Handle = ::HANDLE;
-		constexpr Handle InvalidHandle = INVALID_HANDLE_VALUE;
+		Handle InvalidHandle = INVALID_HANDLE_VALUE;
 		inline bool closeHandle(Handle h) {
 			return ::CloseHandle(h) != 0;
 		}
@@ -82,7 +83,7 @@ namespace wawl {
 				return *reinterpret_cast<::POINT*>(this);
 			}
 			constexpr operator const ::POINT& () const {
-				return *reinterpret_cast<const ::POINT*>(this);
+				return *std::bit_cast<const ::POINT*>(this);
 			}
 		};
 		using Size = Position;

--- a/wawl/Debug.hpp
+++ b/wawl/Debug.hpp
@@ -39,9 +39,9 @@ namespace wawl {
 			std::uint8_t* buffer,
 			std::uint32_t n
 		) {
-			::DWORD readByte;
+			::SIZE_T readByte;
 
-			return (
+			return static_cast<std::uint32_t>((
 				::ReadProcessMemory(
 					procHandle,
 					begin,
@@ -51,7 +51,7 @@ namespace wawl {
 				) != 0
 				? readByte
 				: 0
-				);
+				));
 		}
 		inline std::uint32_t readMemory(
 			Handle procHandle,
@@ -69,9 +69,9 @@ namespace wawl {
 			const void* begin,
 			std::vector<std::uint8_t>& buffer
 		) {
-			::DWORD writtenSize;
+			::SIZE_T writtenSize;
 
-			return (
+			return static_cast<std::uint32_t>((
 				::WriteProcessMemory(
 					procHandle,
 					const_cast<void*>(begin),
@@ -81,7 +81,7 @@ namespace wawl {
 				)
 				? writtenSize
 				: 0
-				);
+				));
 		}
 
 	} // ::wawl::debug

--- a/wawl/Input.hpp
+++ b/wawl/Input.hpp
@@ -11,10 +11,10 @@ namespace wawl {
 	namespace input {
 
 		inline Position getCursorPos() {
-			::LPPOINT pos;
-			::GetCursorPos(pos);
+			::POINT pos = {.x = 0l, .y = 0l};
+			::GetCursorPos(&pos);
 
-			return Position{ pos->x, pos->y };
+			return static_cast<Position>(pos);
 		}
 		inline bool setCursorPos(const Position& pos) {
 			return ::SetCursorPos(pos.x, pos.y) != 0;

--- a/wawl/Window.hpp
+++ b/wawl/Window.hpp
@@ -321,23 +321,19 @@ namespace wawl {
 
 		// convert client coordinate to screen coordinate
 		inline Position toScreenPos(WindowHandle window, const Position& clientPos) {
-			::LPPOINT posBuf;
-			posBuf->x = clientPos.x;
-			posBuf->y = clientPos.y;
+			::POINT posBuf = {.x = clientPos.x, .y = clientPos.y};
 
-			::ClientToScreen(window, posBuf);
+			::ClientToScreen(window, &posBuf);
 
-			return *posBuf;
+			return static_cast<Position>(posBuf);
 		}
 		// convert screen coordinate to client coordinate
 		inline Position toClientPos(WindowHandle window, const Position& screenPos) {
-			::LPPOINT posBuf;
-			posBuf->x = screenPos.x;
-			posBuf->y = screenPos.y;
+			::POINT posBuf = {.x = screenPos.x, .y = screenPos.y};
 
-			::ScreenToClient(window, posBuf);
+			::ScreenToClient(window, &posBuf);
 
-			return *posBuf;
+			return static_cast<Position>(posBuf);
 		}
 
 		// get top most window

--- a/wawl/wawl.vcxproj
+++ b/wawl/wawl.vcxproj
@@ -81,7 +81,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -102,7 +102,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>

--- a/wawl/wawl.vcxproj
+++ b/wawl/wawl.vcxproj
@@ -21,32 +21,32 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C8372A07-1570-4C7D-BB0B-9D6BB7A1FAF1}</ProjectGuid>
     <RootNamespace>wawl</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/wawl/wawl.vcxproj
+++ b/wawl/wawl.vcxproj
@@ -41,7 +41,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -84,6 +84,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -106,6 +107,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>


### PR DESCRIPTION
Due to improper constexpr support by VS2015, constexpr pointer arithmetic was compiled (See [https://learn.microsoft.com/ja-jp/cpp/error-messages/compiler-errors-2/compiler-error-c3615?view=msvc-170&f1url=%3FappId%3DDev16IDEF1%26l%3DJA-JP%26k%3Dk(C3615)%26rd%3Dtrue](https://learn.microsoft.com/ja-jp/cpp/error-messages/compiler-errors-2/compiler-error-c3615?view=msvc-170&f1url=%3FappId%3DDev16IDEF1%26l%3DJA-JP%26k%3Dk(C3615)%26rd%3Dtrue)). However, it is not allowed in C++ and VS2017 and later will not do so.
I removed constexpr modifier from variables and used std::bit_cast for other cases.
Furthermore, some fixes are provided (including unicode setting of project).